### PR TITLE
Bug/enforce whitespace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,3 +28,8 @@ sudo: false
 
 script:
   - make check
+
+addons:
+  apt:
+    packages:
+    - gobjc++

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+#
+#    Copyright 2017 Grant Erickson. All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+#
+#    Description:
+#      This file is the Travis CI hosted, distributed continuous 
+#      integration configuration file for cstyle, a program used to
+#      flexibly and parametrically check for code formatting style
+#      compliance.
+#
+
+language: generic
+
+sudo: false
+
+script:
+  - make check

--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+[![Build Status][cstyle-travis-svg]][cstyle-travis]
+
+cstyle
+======
+
+# Introduction
+
+cstyle is used to flexibly and parametrically check for C and
+C++ code formatting style compliance.
+
+Philosophically, this assumes it is working on compilable
+code. Consequently, this does not endeavor to be nor is it a
+grammatically-correct source code parser.
+
+Where possible, effort is expended to make the syntax, option
+invocation, and output familiar to users of compilers and other
+linting and formatting tools for ease of use and efficient
+system integration.
+
+[cstyle-travis]: https://travis-ci.org/gerickson/cstyle
+[cstyle-travis-svg]: https://travis-ci.org/gerickson/cstyle.svg?branch=master
+
+# Versioning
+
+cstyle follows the [Semantic Versioning guidelines](http://semver.org/) 
+for release cycle transparency and to maintain backwards compatibility.
+
+# License
+
+cstyle is released under the [Apache License, Version 2.0 license](https://opensource.org/licenses/Apache-2.0). 
+See the `LICENSE` file for more information.

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,5 +1,5 @@
 #
-#    Copyright (c) 2001-2016 Grant Erickson
+#    Copyright (c) 2001-2017 Grant Erickson
 #
 #    Description:
 #      Makefile for 'cstyle' coding style and conventions enforcement
@@ -8,19 +8,34 @@
 
 .SUFFIXES: .c .cpp .cmp .mm .stamp .test
 
-CC	 ?= gcc
-CXX	 ?= g++
-OBJC     ?= gcc
-OBJCXX   ?= g++
+CC	     ?= gcc
+CXX	     ?= g++
+OBJC         ?= gcc
+OBJCXX       ?= g++
 
 ifeq ($(DEBUG),1)
 COMPARE      ?= comm -3 --nocheck-order
 else
 COMPARE      ?= cmp -s
 endif
-PERL     ?= perl
-CSTYLE   ?= $(PWD)/../cstyle.pl
-CSTYLE_V := $(CSTYLE) -v
+
+#
+# Always enforce white space checks to ensure our internal unit test
+# files are clean and only contain the warnings of interest.
+#
+PERL         ?= perl
+CSTYLE       ?= $(PWD)/../cstyle.pl
+CSTYLE_FLAGS ?= -Wblank-trailing-space -Wtrailing-line -Wtrailing-space
+CSTYLE_V     := $(CSTYLE) -v $(CSTYLE_FLAGS)
+
+#
+# cstyle-target <option(s)> <input file(s)> <output file>
+#
+define cstyle-target
+@$(PERL) $(CSTYLE_V) $(1) $(2) 2> $(3)
+endef
+
+COPYRIGHT_REGEXP := '^( \*|\/\*|\/\/)    Copyright (\(c\) )*\d{4,}(-\d{4,})* Nest Labs, Inc\.'
 
 %.stamp: %.c
 	@echo "  CC      $<"
@@ -136,14 +151,14 @@ endef
 
 blank-trailing-space.test: blank-trailing-space.cpp blank-trailing-space.cmp blank-trailing-space.stamp $(CSTYLE)
 	@echo "  CHECK   -Wblank-trailing-space..."
-	@$(PERL) $(CSTYLE_V) -Wblank-trailing-space blank-trailing-space.cpp 2> $(@)
+	@$(call cstyle-target,-Wblank-trailing-space,blank-trailing-space.cpp,$(@))
 	@$(call compare-target,$(@))
 
 check-blank-trailing-space: blank-trailing-space.test
 
 no-blank-trailing-space.test: blank-trailing-space.cpp no-blank-trailing-space.cmp blank-trailing-space.stamp $(CSTYLE)
 	@echo "  CHECK   -Wno-blank-trailing-space..."
-	@$(PERL) $(CSTYLE_V) -Wno-blank-trailing-space blank-trailing-space.cpp 2> $(@)
+	@$(call cstyle-target,-Wno-blank-trailing-space,blank-trailing-space.cpp,$(@))
 	@$(call compare-target,$(@))
 
 check-no-blank-trailing-space: no-blank-trailing-space.test
@@ -152,14 +167,14 @@ check-no-blank-trailing-space: no-blank-trailing-space.test
 
 missing-cpp-conditional-labels.test: missing-cpp-conditional-labels.cpp missing-cpp-conditional-labels.cmp missing-cpp-conditional-labels.stamp $(CSTYLE)
 	@echo "  CHECK   -Wmissing-cpp-conditional-labels..."
-	@$(PERL) $(CSTYLE_V) --cpp-lines-between-conditionals=1 -Wmissing-cpp-conditional-labels missing-cpp-conditional-labels.cpp 2> $(@)
+	@$(call cstyle-target,--cpp-lines-between-conditionals=1 -Wmissing-cpp-conditional-labels,missing-cpp-conditional-labels.cpp,$(@))
 	@$(call compare-target,$(@))
 
 check-missing-cpp-conditional-labels: missing-cpp-conditional-labels.test
 
 no-missing-cpp-conditional-labels.test: missing-cpp-conditional-labels.cpp no-missing-cpp-conditional-labels.cmp missing-cpp-conditional-labels.stamp $(CSTYLE)
 	@echo "  CHECK   -Wno-missing-cpp-conditional-labels..."
-	@$(PERL) $(CSTYLE_V) --cpp-lines-between-conditionals=1 -Wno-missing-cpp-conditional-labels missing-cpp-conditional-labels.cpp 2> $(@)
+	@$(call cstyle-target,--cpp-lines-between-conditionals=1 -Wno-missing-cpp-conditional-labels,missing-cpp-conditional-labels.cpp,$(@))
 	@$(call compare-target,$(@))
 
 check-no-missing-cpp-conditional-labels: no-missing-cpp-conditional-labels.test
@@ -168,14 +183,14 @@ check-no-missing-cpp-conditional-labels: no-missing-cpp-conditional-labels.test
 
 cpp-constant-conditionals.test: cpp-constant-conditionals.cpp cpp-constant-conditionals.cmp cpp-constant-conditionals.stamp $(CSTYLE)
 	@echo "  CHECK   -Wcpp-constant-conditionals..."
-	@$(PERL) $(CSTYLE_V) -Wcpp-constant-conditionals cpp-constant-conditionals.cpp 2> $(@)
+	@$(call cstyle-target,-Wcpp-constant-conditionals,cpp-constant-conditionals.cpp,$(@))
 	@$(call compare-target,$(@))
 
 check-cpp-constant-conditionals: cpp-constant-conditionals.test
 
 no-cpp-constant-conditionals.test: cpp-constant-conditionals.cpp no-cpp-constant-conditionals.cmp cpp-constant-conditionals.stamp $(CSTYLE)
 	@echo "  CHECK   -Wno-cpp-constant-conditionals..."
-	@$(PERL) $(CSTYLE_V) -Wno-cpp-constant-conditionals cpp-constant-conditionals.cpp 2> $(@)
+	@$(call cstyle-target,-Wno-cpp-constant-conditionals,cpp-constant-conditionals.cpp,$(@))
 	@$(call compare-target,$(@))
 
 check-no-cpp-constant-conditionals: no-cpp-constant-conditionals.test
@@ -184,14 +199,14 @@ check-no-cpp-constant-conditionals: no-cpp-constant-conditionals.test
 
 cpp-directive-leading-space.test: cpp-directive-leading-space.cpp cpp-directive-leading-space.cmp cpp-directive-leading-space.stamp $(CSTYLE)
 	@echo "  CHECK   -Wcpp-directive-leading-space..."
-	@$(PERL) $(CSTYLE_V) -Wcpp-directive-leading-space cpp-directive-leading-space.cpp 2> $(@)
+	@$(call cstyle-target,-Wcpp-directive-leading-space,cpp-directive-leading-space.cpp,$(@))
 	@$(call compare-target,$(@))
 
 check-cpp-directive-leading-space: cpp-directive-leading-space.test
 
 no-cpp-directive-leading-space.test: cpp-directive-leading-space.cpp no-cpp-directive-leading-space.cmp cpp-directive-leading-space.stamp $(CSTYLE)
 	@echo "  CHECK   -Wno-cpp-directive-leading-space..."
-	@$(PERL) $(CSTYLE_V) -Wno-cpp-directive-leading-space cpp-directive-leading-space.cpp 2> $(@)
+	@$(call cstyle-target,-Wno-cpp-directive-leading-space,cpp-directive-leading-space.cpp,$(@))
 	@$(call compare-target,$(@))
 
 check-no-cpp-directive-leading-space: no-cpp-directive-leading-space.test
@@ -200,14 +215,14 @@ check-no-cpp-directive-leading-space: no-cpp-directive-leading-space.test
 
 file-length.test: file-length.cpp file-length.cmp file-length.stamp $(CSTYLE)
 	@echo "  CHECK   -Wfile-length..."
-	@$(PERL) $(CSTYLE_V) --file-length=5 -Wfile-length file-length.cpp 2> $(@)
+	@$(call cstyle-target,--file-length=5 -Wfile-length,file-length.cpp,$(@))
 	@$(call compare-target,$(@))
 
 check-file-length: file-length.test
 
 no-file-length.test: file-length.cpp no-file-length.cmp file-length.stamp $(CSTYLE)
 	@echo "  CHECK   -Wno-file-length..."
-	@$(PERL) $(CSTYLE_V) --file-length=5 -Wno-file-length file-length.cpp 2> $(@)
+	@$(call cstyle-target,--file-length=5 -Wno-file-length,file-length.cpp,$(@))
 	@$(call compare-target,$(@))
 
 check-no-file-length: no-file-length.test
@@ -216,14 +231,14 @@ check-no-file-length: no-file-length.test
 
 implicit-void-declaration.test: implicit-void-declaration.cpp implicit-void-declaration.cmp implicit-void-declaration.stamp $(CSTYLE)
 	@echo "  CHECK   -Wimplicit-void-declaration..."
-	@$(PERL) $(CSTYLE_V) -Wimplicit-void-declaration implicit-void-declaration.cpp 2> $(@)
+	@$(call cstyle-target,-Wimplicit-void-declaration,implicit-void-declaration.cpp,$(@))
 	@$(call compare-target,$(@))
 
 check-implicit-void-declaration: implicit-void-declaration.test
 
 no-implicit-void-declaration.test: implicit-void-declaration.cpp no-implicit-void-declaration.cmp implicit-void-declaration.stamp $(CSTYLE)
 	@echo "  CHECK   -Wno-implicit-void-declaration..."
-	@$(PERL) $(CSTYLE_V) -Wno-implicit-void-declaration implicit-void-declaration.cpp 2> $(@)
+	@$(call cstyle-target,-Wno-implicit-void-declaration,implicit-void-declaration.cpp,$(@))
 	@$(call compare-target,$(@))
 
 check-no-implicit-void-declaration: no-implicit-void-declaration.test
@@ -232,14 +247,14 @@ check-no-implicit-void-declaration: no-implicit-void-declaration.test
 
 interpolated-space.test: interpolated-space.cpp interpolated-space.cmp interpolated-space.stamp $(CSTYLE)
 	@echo "  CHECK   -Winterpolated-space..."
-	@$(PERL) $(CSTYLE_V) -Winterpolated-space interpolated-space.cpp 2> $(@)
+	@$(call cstyle-target,-Winterpolated-space,interpolated-space.cpp,$(@))
 	@$(call compare-target,$(@))
 
 check-interpolated-space: interpolated-space.test
 
 no-interpolated-space.test: interpolated-space.cpp no-interpolated-space.cmp interpolated-space.stamp $(CSTYLE)
 	@echo "  CHECK   -Wno-interpolated-space..."
-	@$(PERL) $(CSTYLE_V) -Wno-interpolated-space interpolated-space.cpp 2> $(@)
+	@$(call cstyle-target,-Wno-interpolated-space,interpolated-space.cpp,$(@))
 	@$(call compare-target,$(@))
 
 check-no-interpolated-space: no-interpolated-space.test
@@ -248,14 +263,14 @@ check-no-interpolated-space: no-interpolated-space.test
 
 line-length.test: line-length.cpp line-length.cmp line-length.stamp $(CSTYLE)
 	@echo "  CHECK   -Wline-length..."
-	@$(PERL) $(CSTYLE_V) --line-length=80 --tab-size=4 -Wline-length line-length.cpp 2> $(@)
+	@$(call cstyle-target,--line-length=80 --tab-size=4 -Wline-length,line-length.cpp,$(@))
 	@$(call compare-target,$(@))
 
 check-line-length: line-length.test
 
 no-line-length.test: line-length.cpp no-line-length.cmp line-length.stamp $(CSTYLE)
 	@echo "  CHECK   -Wno-line-length..."
-	@$(PERL) $(CSTYLE_V) --line-length=80 --tab-size=4 -Wno-line-length line-length.cpp 2> $(@)
+	@$(call cstyle-target,--line-length=80 --tab-size=4 -Wno-line-length,line-length.cpp,$(@))
 	@$(call compare-target,$(@))
 
 check-no-line-length: no-line-length.test
@@ -264,14 +279,14 @@ check-no-line-length: no-line-length.test
 
 missing-copyright.test: missing-copyright.cpp missing-copyright.cmp missing-copyright.stamp $(CSTYLE)
 	@echo "  CHECK   -Wmissing-copyright..."
-	@$(PERL) $(CSTYLE_V) --copyright='^( \*|\/\*|\/\/)    Copyright (\(c\) )*\d{4,}(-\d{4,})* Nest Labs, Inc\.' -Wmissing-copyright missing-copyright.cpp 2> $(@)
+	@$(call cstyle-target,--copyright=$(COPYRIGHT_REGEXP) -Wmissing-copyright,missing-copyright.cpp,$(@))
 	@$(call compare-target,$(@))
 
 check-missing-copyright: missing-copyright.test
 
 no-missing-copyright.test: no-missing-copyright.cpp no-missing-copyright.cmp no-missing-copyright.stamp $(CSTYLE)
 	@echo "  CHECK   -Wno-missing-copyright..."
-	@$(PERL) $(CSTYLE_V) --copyright='^( \*|\/\*|\/\/)    Copyright (\(c\) )*\d{4,}(-\d{4,})* Nest Labs, Inc\.' -Wno-missing-copyright no-missing-copyright.cpp 2> $(@)
+	@$(call cstyle-target,--copyright=--copyright=$(COPYRIGHT_REGEXP) -Wno-missing-copyright,no-missing-copyright.cpp,$(@))
 	@$(call compare-target,$(@))
 
 check-no-missing-copyright: no-missing-copyright.test
@@ -280,14 +295,14 @@ check-no-missing-copyright: no-missing-copyright.test
 
 missing-newline-at-eof.test: missing-newline-at-eof.cpp missing-newline-at-eof.cmp missing-newline-at-eof.stamp $(CSTYLE)
 	@echo "  CHECK   -Wmissing-newline-at-eof..."
-	@$(PERL) $(CSTYLE_V) -Wmissing-newline-at-eof missing-newline-at-eof.cpp 2> $(@)
+	@$(call cstyle-target,-Wmissing-newline-at-eof,missing-newline-at-eof.cpp,$(@))
 	@$(call compare-target,$(@))
 
 check-missing-newline-at-eof: missing-newline-at-eof.test
 
 no-missing-newline-at-eof.test: missing-newline-at-eof.cpp no-missing-newline-at-eof.cmp missing-newline-at-eof.stamp $(CSTYLE)
 	@echo "  CHECK   -Wno-missing-newline-at-eof..."
-	@$(PERL) $(CSTYLE_V) -Wno-missing-newline-at-eof missing-newline-at-eof.cpp 2> $(@)
+	@$(call cstyle-target,-Wno-missing-newline-at-eof,missing-newline-at-eof.cpp,$(@))
 	@$(call compare-target,$(@))
 
 check-no-missing-newline-at-eof: no-missing-newline-at-eof.test
@@ -296,14 +311,14 @@ check-no-missing-newline-at-eof: no-missing-newline-at-eof.test
 
 missing-space-after-comma.test: missing-space-after-comma.cpp missing-space-after-comma.cmp missing-space-after-comma.stamp $(CSTYLE)
 	@echo "  CHECK   -Wmissing-space-after-comma..."
-	@$(PERL) $(CSTYLE_V) -Wmissing-space-after-comma missing-space-after-comma.cpp 2> $(@)
+	@$(call cstyle-target,-Wmissing-space-after-comma,missing-space-after-comma.cpp,$(@))
 	@$(call compare-target,$(@))
 
 check-missing-space-after-comma: missing-space-after-comma.test
 
 no-missing-space-after-comma.test: missing-space-after-comma.cpp no-missing-space-after-comma.cmp missing-space-after-comma.stamp $(CSTYLE)
 	@echo "  CHECK   -Wno-missing-space-after-comma..."
-	@$(PERL) $(CSTYLE_V) -Wno-missing-space-after-comma missing-space-after-comma.cpp 2> $(@)
+	@$(call cstyle-target,-Wno-missing-space-after-comma,missing-space-after-comma.cpp,$(@))
 	@$(call compare-target,$(@))
 
 check-no-missing-space-after-comma: no-missing-space-after-comma.test
@@ -312,14 +327,14 @@ check-no-missing-space-after-comma: no-missing-space-after-comma.test
 
 missing-space-after-else-if.test: missing-space-after-else-if.cpp missing-space-after-else-if.cmp missing-space-after-else-if.stamp $(CSTYLE)
 	@echo "  CHECK   -Wmissing-space-after-else-if..."
-	@$(PERL) $(CSTYLE_V) -Wmissing-space-after-else-if missing-space-after-else-if.cpp 2> $(@)
+	@$(call cstyle-target,-Wmissing-space-after-else-if,missing-space-after-else-if.cpp,$(@))
 	@$(call compare-target,$(@))
 
 check-missing-space-after-else-if: missing-space-after-else-if.test
 
 no-missing-space-after-else-if.test: missing-space-after-else-if.cpp no-missing-space-after-else-if.cmp missing-space-after-else-if.stamp $(CSTYLE)
 	@echo "  CHECK   -Wno-missing-space-after-else-if..."
-	@$(PERL) $(CSTYLE_V) -Wno-missing-space-after-else-if missing-space-after-else-if.cpp 2> $(@)
+	@$(call cstyle-target,-Wno-missing-space-after-else-if,missing-space-after-else-if.cpp,$(@))
 	@$(call compare-target,$(@))
 
 check-no-missing-space-after-else-if: no-missing-space-after-else-if.test
@@ -328,14 +343,14 @@ check-no-missing-space-after-else-if: no-missing-space-after-else-if.test
 
 missing-space-after-for.test: missing-space-after-for.cpp missing-space-after-for.cmp missing-space-after-for.stamp $(CSTYLE)
 	@echo "  CHECK   -Wmissing-space-after-for..."
-	@$(PERL) $(CSTYLE_V) -Wmissing-space-after-for missing-space-after-for.cpp 2> $(@)
+	@$(call cstyle-target,-Wmissing-space-after-for,missing-space-after-for.cpp,$(@))
 	@$(call compare-target,$(@))
 
 check-missing-space-after-for: missing-space-after-for.test
 
 no-missing-space-after-for.test: missing-space-after-for.cpp no-missing-space-after-for.cmp missing-space-after-for.stamp $(CSTYLE)
 	@echo "  CHECK   -Wno-missing-space-after-for..."
-	@$(PERL) $(CSTYLE_V) -Wno-missing-space-after-for missing-space-after-for.cpp 2> $(@)
+	@$(call cstyle-target,-Wno-missing-space-after-for,missing-space-after-for.cpp,$(@))
 	@$(call compare-target,$(@))
 
 check-no-missing-space-after-for: no-missing-space-after-for.test
@@ -344,14 +359,14 @@ check-no-missing-space-after-for: no-missing-space-after-for.test
 
 missing-space-after-if.test: missing-space-after-if.cpp missing-space-after-if.cmp missing-space-after-if.stamp $(CSTYLE)
 	@echo "  CHECK   -Wmissing-space-after-if..."
-	@$(PERL) $(CSTYLE_V) -Wmissing-space-after-if missing-space-after-if.cpp 2> $(@)
+	@$(call cstyle-target,-Wmissing-space-after-if,missing-space-after-if.cpp,$(@))
 	@$(call compare-target,$(@))
 
 check-missing-space-after-if: missing-space-after-if.test
 
 no-missing-space-after-if.test: missing-space-after-if.cpp no-missing-space-after-if.cmp missing-space-after-if.stamp $(CSTYLE)
 	@echo "  CHECK   -Wno-missing-space-after-if..."
-	@$(PERL) $(CSTYLE_V) -Wno-missing-space-after-if missing-space-after-if.cpp 2> $(@)
+	@$(call cstyle-target,-Wno-missing-space-after-if,missing-space-after-if.cpp,$(@))
 	@$(call compare-target,$(@))
 
 check-no-missing-space-after-if: no-missing-space-after-if.test
@@ -360,14 +375,14 @@ check-no-missing-space-after-if: no-missing-space-after-if.test
 
 missing-space-after-operator.test: missing-space-after-operator.cpp missing-space-after-operator.cmp missing-space-after-operator.stamp $(CSTYLE)
 	@echo "  CHECK   -Wmissing-space-after-operator..."
-	@$(PERL) $(CSTYLE_V) -Wmissing-space-after-operator missing-space-after-operator.cpp 2> $(@)
+	@$(call cstyle-target,-Wmissing-space-after-operator,missing-space-after-operator.cpp,$(@))
 	@$(call compare-target,$(@))
 
 check-missing-space-after-operator: missing-space-after-operator.test
 
 no-missing-space-after-operator.test: missing-space-after-operator.cpp no-missing-space-after-operator.cmp missing-space-after-operator.stamp $(CSTYLE)
 	@echo "  CHECK   -Wno-missing-space-after-operator..."
-	@$(PERL) $(CSTYLE_V) -Wno-missing-space-after-operator missing-space-after-operator.cpp 2> $(@)
+	@$(call cstyle-target,-Wno-missing-space-after-operator,missing-space-after-operator.cpp,$(@))
 	@$(call compare-target,$(@))
 
 check-no-missing-space-after-operator: no-missing-space-after-operator.test
@@ -376,14 +391,14 @@ check-no-missing-space-after-operator: no-missing-space-after-operator.test
 
 missing-space-after-semicolon.test: missing-space-after-semicolon.cpp missing-space-after-semicolon.cmp missing-space-after-semicolon.stamp $(CSTYLE)
 	@echo "  CHECK   -Wmissing-space-after-semicolon..."
-	@$(PERL) $(CSTYLE_V) -Wmissing-space-after-semicolon missing-space-after-semicolon.cpp 2> $(@)
+	@$(call cstyle-target,-Wmissing-space-after-semicolon,missing-space-after-semicolon.cpp,$(@))
 	@$(call compare-target,$(@))
 
 check-missing-space-after-semicolon: missing-space-after-semicolon.test
 
 no-missing-space-after-semicolon.test: missing-space-after-semicolon.cpp no-missing-space-after-semicolon.cmp missing-space-after-semicolon.stamp $(CSTYLE)
 	@echo "  CHECK   -Wno-missing-space-after-semicolon..."
-	@$(PERL) $(CSTYLE_V) -Wno-missing-space-after-semicolon missing-space-after-semicolon.cpp 2> $(@)
+	@$(call cstyle-target,-Wno-missing-space-after-semicolon,missing-space-after-semicolon.cpp,$(@))
 	@$(call compare-target,$(@))
 
 check-no-missing-space-after-semicolon: no-missing-space-after-semicolon.test
@@ -392,14 +407,14 @@ check-no-missing-space-after-semicolon: no-missing-space-after-semicolon.test
 
 missing-space-after-switch.test: missing-space-after-switch.cpp missing-space-after-switch.cmp missing-space-after-switch.stamp $(CSTYLE)
 	@echo "  CHECK   -Wmissing-space-after-switch..."
-	@$(PERL) $(CSTYLE_V) -Wmissing-space-after-switch missing-space-after-switch.cpp 2> $(@)
+	@$(call cstyle-target,-Wmissing-space-after-switch,missing-space-after-switch.cpp,$(@))
 	@$(call compare-target,$(@))
 
 check-missing-space-after-switch: missing-space-after-switch.test
 
 no-missing-space-after-switch.test: missing-space-after-switch.cpp no-missing-space-after-switch.cmp missing-space-after-switch.stamp $(CSTYLE)
 	@echo "  CHECK   -Wno-missing-space-after-switch..."
-	@$(PERL) $(CSTYLE_V) -Wno-missing-space-after-switch missing-space-after-switch.cpp 2> $(@)
+	@$(call cstyle-target,-Wno-missing-space-after-switch,missing-space-after-switch.cpp,$(@))
 	@$(call compare-target,$(@))
 
 check-no-missing-space-after-switch: no-missing-space-after-switch.test
@@ -408,14 +423,14 @@ check-no-missing-space-after-switch: no-missing-space-after-switch.test
 
 missing-space-after-while.test: missing-space-after-while.cpp missing-space-after-while.cmp missing-space-after-while.stamp $(CSTYLE)
 	@echo "  CHECK   -Wmissing-space-after-while..."
-	@$(PERL) $(CSTYLE_V) -Wmissing-space-after-while missing-space-after-while.cpp 2> $(@)
+	@$(call cstyle-target,-Wmissing-space-after-while,missing-space-after-while.cpp,$(@))
 	@$(call compare-target,$(@))
 
 check-missing-space-after-while: missing-space-after-while.test
 
 no-missing-space-after-while.test: missing-space-after-while.cpp no-missing-space-after-while.cmp missing-space-after-while.stamp $(CSTYLE)
 	@echo "  CHECK   -Wno-missing-space-after-while..."
-	@$(PERL) $(CSTYLE_V) -Wno-missing-space-after-while missing-space-after-while.cpp 2> $(@)
+	@$(call cstyle-target,-Wno-missing-space-after-while,missing-space-after-while.cpp,$(@))
 	@$(call compare-target,$(@))
 
 check-no-missing-space-after-while: no-missing-space-after-while.test
@@ -424,14 +439,14 @@ check-no-missing-space-after-while: no-missing-space-after-while.test
 
 missing-space-around-binary-operators.test: missing-space-around-binary-operators.cpp missing-space-around-binary-operators.cmp missing-space-around-binary-operators.stamp $(CSTYLE)
 	@echo "  CHECK   -Wmissing-space-around-binary-operators..."
-	@$(PERL) $(CSTYLE_V) -Wmissing-space-around-binary-operators missing-space-around-binary-operators.cpp 2> $(@)
+	@$(call cstyle-target,-Wmissing-space-around-binary-operators,missing-space-around-binary-operators.cpp,$(@))
 	@$(call compare-target,$(@))
 
 check-missing-space-around-binary-operators: missing-space-around-binary-operators.test
 
 no-missing-space-around-binary-operators.test: missing-space-around-binary-operators.cpp no-missing-space-around-binary-operators.cmp missing-space-around-binary-operators.stamp $(CSTYLE)
 	@echo "  CHECK   -Wno-missing-space-around-binary-operators..."
-	@$(PERL) $(CSTYLE_V) -Wno-missing-space-around-binary-operators missing-space-around-binary-operators.cpp 2> $(@)
+	@$(call cstyle-target,-Wno-missing-space-around-binary-operators,missing-space-around-binary-operators.cpp,$(@))
 	@$(call compare-target,$(@))
 
 check-no-missing-space-around-binary-operators: no-missing-space-around-binary-operators.test
@@ -440,14 +455,14 @@ check-no-missing-space-around-binary-operators: no-missing-space-around-binary-o
 
 missing-space-around-braces.test: missing-space-around-braces.mm missing-space-around-braces.cmp missing-space-around-braces.stamp $(CSTYLE)
 	@echo "  CHECK   -Wmissing-space-around-braces..."
-	@$(PERL) $(CSTYLE_V) -Wmissing-space-around-braces missing-space-around-braces.mm 2> $(@)
+	@$(call cstyle-target,-Wmissing-space-around-braces,missing-space-around-braces.mm,$(@))
 	@$(call compare-target,$(@))
 
 check-missing-space-around-braces: missing-space-around-braces.test
 
 no-missing-space-around-braces.test: missing-space-around-braces.mm no-missing-space-around-braces.cmp missing-space-around-braces.stamp $(CSTYLE)
 	@echo "  CHECK   -Wno-missing-space-around-braces..."
-	@$(PERL) $(CSTYLE_V) -Wno-missing-space-around-braces missing-space-around-braces.mm 2> $(@)
+	@$(call cstyle-target,-Wno-missing-space-around-braces,missing-space-around-braces.mm,$(@))
 	@$(call compare-target,$(@))
 
 check-no-missing-space-around-braces: no-missing-space-around-braces.test
@@ -456,14 +471,14 @@ check-no-missing-space-around-braces: no-missing-space-around-braces.test
 
 space-around-unary-operators.test: space-around-unary-operators.cpp space-around-unary-operators.cmp space-around-unary-operators.stamp $(CSTYLE)
 	@echo "  CHECK   -Wspace-around-unary-operators..."
-	@$(PERL) $(CSTYLE_V) -Wspace-around-unary-operators space-around-unary-operators.cpp 2> $(@)
+	@$(call cstyle-target,-Wspace-around-unary-operators,space-around-unary-operators.cpp,$(@))
 	@$(call compare-target,$(@))
 
 check-space-around-unary-operators: space-around-unary-operators.test
 
 no-space-around-unary-operators.test: space-around-unary-operators.cpp no-space-around-unary-operators.cmp space-around-unary-operators.stamp $(CSTYLE)
 	@echo "  CHECK   -Wno-space-around-unary-operators..."
-	@$(PERL) $(CSTYLE_V) -Wno-space-around-unary-operators space-around-unary-operators.cpp 2> $(@)
+	@$(call cstyle-target,-Wno-space-around-unary-operators,space-around-unary-operators.cpp,$(@))
 	@$(call compare-target,$(@))
 
 check-no-space-around-unary-operators: no-space-around-unary-operators.test
@@ -472,14 +487,14 @@ check-no-space-around-unary-operators: no-space-around-unary-operators.test
 
 trailing-line.test: trailing-line.cpp trailing-line.cmp trailing-line.stamp $(CSTYLE)
 	@echo "  CHECK   -Wtrailing-line..."
-	@$(PERL) $(CSTYLE_V) -Wtrailing-line trailing-line.cpp 2> $(@)
+	@$(call cstyle-target,-Wtrailing-line,trailing-line.cpp,$(@))
 	@$(call compare-target,$(@))
 
 check-trailing-line: trailing-line.test
 
 no-trailing-line.test: trailing-line.cpp no-trailing-line.cmp trailing-line.stamp $(CSTYLE)
 	@echo "  CHECK   -Wno-trailing-line..."
-	@$(PERL) $(CSTYLE_V) -Wno-trailing-line trailing-line.cpp 2> $(@)
+	@$(call cstyle-target,-Wno-trailing-line,trailing-line.cpp,$(@))
 	@$(call compare-target,$(@))
 
 check-no-trailing-line: no-trailing-line.test
@@ -488,14 +503,14 @@ check-no-trailing-line: no-trailing-line.test
 
 trailing-space.test: trailing-space.cpp trailing-space.cmp trailing-space.stamp $(CSTYLE)
 	@echo "  CHECK   -Wtrailing-space..."
-	@$(PERL) $(CSTYLE_V) -Wtrailing-space trailing-space.cpp 2> $(@)
+	@$(call cstyle-target,-Wtrailing-space,trailing-space.cpp,$(@))
 	@$(call compare-target,$(@))
 
 check-trailing-space: trailing-space.test
 
 no-trailing-space.test: trailing-space.cpp no-trailing-space.cmp trailing-space.stamp $(CSTYLE)
 	@echo "  CHECK   -Wno-trailing-space..."
-	@$(PERL) $(CSTYLE_V) -Wno-trailing-space trailing-space.cpp 2> $(@)
+	@$(call cstyle-target,-Wno-trailing-space,trailing-space.cpp,$(@))
 	@$(call compare-target,$(@))
 
 check-no-trailing-space: no-trailing-space.test

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -8,8 +8,8 @@
 
 .SUFFIXES: .c .cpp .cmp .mm .stamp .test
 
-CC	     ?= gcc
-CXX	     ?= g++
+CC           ?= gcc
+CXX          ?= g++
 OBJC         ?= gcc
 OBJCXX       ?= g++
 

--- a/tests/blank-trailing-space.cpp
+++ b/tests/blank-trailing-space.cpp
@@ -1,8 +1,8 @@
-// This comment includes trailing space.
+// The line below this comment includes blank trailing space.
 	
 /*
- * This multi-line comment
- * includes trailing space.
+ * This line below this multi-line
+ * comment includes blank trailing space.
  */
   
 int TrailingSpace(void)

--- a/tests/blank-trailing-space.cpp
+++ b/tests/blank-trailing-space.cpp
@@ -1,13 +1,13 @@
-// This comment includes trailing space. 
+// This comment includes trailing space.
 	
 /*
- * This multi-line comment	
- * includes trailing space.	
+ * This multi-line comment
+ * includes trailing space.
  */
   
-int TrailingSpace(void) 
-{ 
-    return 0; 
-} 
+int TrailingSpace(void)
+{
+    return 0;
+}
   
 		

--- a/tests/cpp-constant-conditionals.cpp
+++ b/tests/cpp-constant-conditionals.cpp
@@ -137,4 +137,3 @@ int FunctionToExclude_10(void)
     return 0;
 }
 #endif
-

--- a/tests/cpp-directive-leading-space.cpp
+++ b/tests/cpp-directive-leading-space.cpp
@@ -39,4 +39,3 @@
 	 	#if CPP_DIRECTIVE_LEADING_SPACE
 
 	 	#endif
-

--- a/tests/missing-newline-at-eof.cmp
+++ b/tests/missing-newline-at-eof.cmp
@@ -1,3 +1,3 @@
-missing-newline-at-eof.cpp:0:1: warning: missing new line at the end of file
-
+missing-newline-at-eof.cpp:4:1: warning: missing new line at the end of file
+}
 ^

--- a/tests/missing-newline-at-eof.cpp
+++ b/tests/missing-newline-at-eof.cpp
@@ -1,0 +1,4 @@
+int main(void)
+{
+	return 0;
+}

--- a/tests/missing-space-after-comma.cpp
+++ b/tests/missing-space-after-comma.cpp
@@ -32,7 +32,7 @@ static wchar_t charsets[] =
  */
 
 static int array_1[] = {0,1,2,3,4,5};	// These should generate a violation
-static int array_2[] = {0,		// End of line, these should not 
+static int array_2[] = {0,		// End of line, these should not
                         1,		// generate a violation.
                         2,
                         3,

--- a/tests/missing-space-after-operator.cpp
+++ b/tests/missing-space-after-operator.cpp
@@ -114,11 +114,3 @@ class test_6
     int operator ()(int a);
     int operator [](size_t a);
 };
-
-
-
-
-
-
-
-

--- a/tests/missing-space-after-switch.cpp
+++ b/tests/missing-space-after-switch.cpp
@@ -11,7 +11,7 @@ void test_1(int aArgument)
     case 1:
         describe("The value is odd");
         break;
-        
+
     case 2:
         describe("The value is even");
         break;
@@ -31,7 +31,7 @@ void test_2(int aArgument)
     case 1:
         describe("The value is odd");
         break;
-        
+
     case 2:
         describe("The value is even");
         break;

--- a/tests/missing-space-around-binary-operators.cpp
+++ b/tests/missing-space-around-binary-operators.cpp
@@ -19,7 +19,7 @@ void test_1(void)
     c=1;
 
     // Binary arithmetic operators
-    
+
     c = (a+b);
     c = (a*b);
     c = (a-b);
@@ -82,7 +82,7 @@ void test_2_1(void)
     c =1;
 
     // Binary arithmetic operators
-    
+
     c = (a +b);
     c = (a *b);
     c = (a -b);
@@ -145,7 +145,7 @@ void test_2_2(void)
     c  =1;
 
     // Binary arithmetic operators
-    
+
     c = (a  +b);
     c = (a  *b);
     c = (a  -b);
@@ -208,7 +208,7 @@ void test_3_1(void)
     c= 1;
 
     // Binary arithmetic operators
-    
+
     c = (a+ b);
     c = (a* b);
     c = (a- b);
@@ -271,7 +271,7 @@ void test_3_2(void)
     c=  1;
 
     // Binary arithmetic operators
-    
+
     c = (a+  b);
     c = (a*  b);
     c = (a-  b);
@@ -334,7 +334,7 @@ void test_4_1(void)
     c	=1;
 
     // Binary arithmetic operators
-    
+
     c = (a	+b);
     c = (a	*b);
     c = (a	-b);
@@ -397,7 +397,7 @@ void test_4_2(void)
     c		=1;
 
     // Binary arithmetic operators
-    
+
     c = (a		+b);
     c = (a		*b);
     c = (a		-b);
@@ -460,7 +460,7 @@ void test_5_1(void)
     c=	1;
 
     // Binary arithmetic operators
-    
+
     c = (a+	b);
     c = (a*	b);
     c = (a-	b);
@@ -523,7 +523,7 @@ void test_5_2(void)
     c=		1;
 
     // Binary arithmetic operators
-    
+
     c = (a+		b);
     c = (a*		b);
     c = (a-		b);
@@ -586,7 +586,7 @@ void test_6(void)
     c=(1);
 
     // Binary arithmetic operators
-    
+
     c = ((a)+(b));
     c = ((a)*(b));
     c = ((a)-(b));

--- a/tests/multiple-returns.cpp
+++ b/tests/multiple-returns.cpp
@@ -9,16 +9,16 @@ class _Test1
 {
 public:
     _Test1(void) { return; }
-    ~Test1(void) { return; }
+    ~_Test1(void) { return; }
 
-    int Mul(int bar) { return (bar * 3); }
+    static int Mul(int bar) { return (bar * 3); }
 
     static void Baz(int bar)
     {
         if (bar)
             sMoof += bar;
         else
-            sMoof += mul(bar);
+            sMoof += Mul(bar);
 
         return;
     }

--- a/tests/space-around-unary-operators.cpp
+++ b/tests/space-around-unary-operators.cpp
@@ -279,4 +279,3 @@ bool test_6_2n(void)
 
     return !(b);
 }
-

--- a/tests/trailing-space.cpp
+++ b/tests/trailing-space.cpp
@@ -1,10 +1,10 @@
 // This comment includes trailing space. 
- 
+
 /*
  * This multi-line comment	
  * includes trailing space.	
  */
-  
+
 int TrailingSpace(void) 
 { 
     return 0; 


### PR DESCRIPTION
This change addresses an issue in which errant style issues outside of the unit test focus area occurs in unit test source files.

As a result , we always enforce white space checks to ensure our internal unit test files are clean and only contain the warnings of interest.