### PR TITLE
Deprecate Travis CI in lieu of GitHub Actions.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Install Common Host Package Dependencies
       run: |
         sudo apt-get update
-        sudo apt-get -y gobjc++
+        sudo apt-get -y install gobjc++
 
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,8 @@ jobs:
     runs-on: macos-latest
     name: "macOS"
 
+    steps:
+
     - name: Checkout
       uses: actions/checkout@v2
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 #
-#    Copyright 2017 Grant Erickson. All Rights Reserved.
+#    Copyright 2017-2022 Grant Erickson. All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -16,20 +16,52 @@
 
 #
 #    Description:
-#      This file is the Travis CI hosted, distributed continuous 
+#      This file is the GitHub Actions hosted, distributed continuous 
 #      integration configuration file for cstyle, a program used to
 #      flexibly and parametrically check for code formatting style
 #      compliance.
 #
 
-language: generic
+---
+name: Build
 
-sudo: false
+on: [push, pull_request]
 
-script:
-  - make check
+jobs:
 
-addons:
-  apt:
-    packages:
-    - gobjc++
+  linux:
+    runs-on: ubuntu-latest
+    name: "Linux"
+
+    steps:
+
+    - name: Install Common Host Package Dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get -y gobjc++
+
+    - name: Checkout
+      uses: actions/checkout@v2
+    
+    - name: Build
+      run: |
+        make
+
+    - name: Test
+      run: |
+        make check
+
+  macos:
+    runs-on: macos-latest
+    name: "macOS"
+
+    - name: Checkout
+      uses: actions/checkout@v2
+    
+    - name: Build
+      run: |
+        make
+
+    - name: Test
+      run: |
+        make check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,11 @@
 #
-#    Copyright 2017-2022 Grant Erickson. All Rights Reserved.
+#    Copyright (c) 2017-2022 Grant Erickson. All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
 #    You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#        http://www.apache.org/licenses/LICENSE-2.0
 #
 #    Unless required by applicable law or agreed to in writing, software
 #    distributed under the License is distributed on an "AS IS" BASIS,
@@ -42,7 +42,7 @@ jobs:
 
     - name: Checkout
       uses: actions/checkout@v2
-    
+
     - name: Build
       run: |
         make
@@ -57,7 +57,7 @@ jobs:
 
     - name: Checkout
       uses: actions/checkout@v2
-    
+
     - name: Build
       run: |
         make

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-[![Build Status][cstyle-travis-svg]][cstyle-travis]
+[![Build Status][cstyle-github-action-svg]][cstyle-github-action]
+
+[cstyle-github]: https://github.com/gerickson/cstyle
+[cstyle-github-action]: https://github.com/gerickson/cstyle/actions?query=workflow%3Abuild+branch%3Amaster+event%3Apush
+[cstyle-github-action-svg]: https://github.com/gerickson/cstyle/actions/workflows/build.yml/badge.svg?branch=master&event=push
 
 cstyle
 ======
@@ -16,9 +20,6 @@ Where possible, effort is expended to make the syntax, option
 invocation, and output familiar to users of compilers and other
 linting and formatting tools for ease of use and efficient
 system integration.
-
-[cstyle-travis]: https://travis-ci.org/gerickson/cstyle
-[cstyle-travis-svg]: https://travis-ci.org/gerickson/cstyle.svg?branch=master
 
 # Versioning
 


### PR DESCRIPTION
This deprecates Travis CI in lieu of an equivalent set of GitHub Actions for continuous integration.